### PR TITLE
Fix Issue#1: endless loop with --verbose

### DIFF
--- a/genext2fs.c
+++ b/genext2fs.c
@@ -3025,7 +3025,7 @@ out:
 static void
 print_fs(filesystem *fs)
 {
-	uint32 i;
+	uint32 i, j;
 	blk_info *bi;
 	groupdescriptor *gd;
 	gd_info *gi;
@@ -3058,9 +3058,9 @@ print_fs(filesystem *fs)
 		printf("inode bitmap allocation:\n");
 		ibm = GRP_GET_GROUP_IBM(fs, gd, &bi);
 		print_bm(ibm, fs->sb->s_inodes_per_group);
-		for (i = 1; i <= fs->sb->s_inodes_per_group; i++)
-			if (allocated(ibm, i))
-				print_inode(fs, i);
+		for (j = 1; j <= fs->sb->s_inodes_per_group; j++)
+			if (allocated(ibm, j))
+				print_inode(fs, j);
 		GRP_PUT_GROUP_IBM(bi);
 		put_gd(gi);
 	}


### PR DESCRIPTION
A printing loop reused the loop variable i of the outer loop
which caused the issue. Here is copied from the bug report
made by MartinEmrich:

How to reproduce:

genext2fs -b 1000000 -d testfolder -m 1 -z -U --verbose testimage.ext2

gets stuck in an endless loop. Removing the --verbose flag makes
printing succeed.

Signed-off-by: Yefu Wang <m@yefu.org>