### PR TITLE
Update unconditionally fs to rev1

### DIFF
--- a/genext2fs.c
+++ b/genext2fs.c
@@ -3370,6 +3370,7 @@ main(int argc, char **argv)
 			fs_timestamp = time(NULL);
 		fs = init_fs(nbblocks, nbinodes, nbresrvd, holes,
 			     fs_timestamp, creator_os, bigendian, fsout);
+		fs_upgrade_rev1_largefile(fs);
 	}
 	if (volumelabel != NULL)
 		strncpy((char *)fs->sb->s_volume_name, volumelabel,


### PR DESCRIPTION
This avoids following kernel warning (Linux 4.9):

    [ 2233.819890] EXT4-fs (mmcblk0p3): couldn't mount as ext3 due to feature incompatibilities
    [ 2233.834532] EXT4-fs warning (device mmcblk0p3): ext4_update_dynamic_rev:750: updating to rev 1 because of new feature flag, running e2fsck is recommended

In fact, the rev0 is quite pretty old. Even Linux 2.4 already supported rev1.