### PR TITLE
allow reading from tarball on stdin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 bin_PROGRAMS = genext2fs
 genext2fs_SOURCES = genext2fs.c
+genext2fs_LDADD = $(ARCHIVE_LIBS)
 man_MANS = genext2fs.8
 EXTRA_DIST = $(man_MANS) test-gen.lib test-mount.sh test.sh device_table.txt device_table_link.txt cache.h list.h m4/ac_func_scanf_can_malloc.m4 m4/ac_func_snprintf.m4
 TESTS = test.sh

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,27 @@ AC_CHECK_FUNCS([getopt_long getline strtof])
 AC_FUNC_SNPRINTF
 AC_FUNC_SCANF_CAN_MALLOC
 
+AC_MSG_CHECKING(--enable-libarchive argument)
+AC_ARG_ENABLE(libarchive,
+    [  --enable-libarchive        Include libarchive support.],
+    [enable_libarchive=$enableval],
+    [enable_libarchive="no"])
+AC_MSG_RESULT($enable_libarchive)
+if test "$enable_libarchive" = "yes"; then
+# Check for libarchive (no pkg-config support)
+AC_CHECK_LIB([archive], [archive_read_new], [ARCHIVE_LIBS=-larchive],
+    AC_MSG_ERROR([libarchive not found.
+                  If libarchive is installed then perhaps you should set
+                  the LDFLAGS=-L/nonstandard/lib/dir environment variable]))
+AC_SUBST([ARCHIVE_LIBS])
+AC_CHECK_HEADERS([archive.h archive_entry.h],,
+    AC_MSG_ERROR([libarchive headers not found.
+                  If the libarchive headers are installed then perhaps you
+                  should set the CPPFLAGS=-I/nonstandard/include/dir
+                  environment variable]))
+AC_DEFINE([HAVE_LIBARCHIVE], [], [Description])
+fi
+
 AC_OUTPUT([Makefile],[
 chmod a+x $ac_top_srcdir/test-mount.sh $ac_top_srcdir/test.sh
 ])

--- a/test-gen.lib
+++ b/test-gen.lib
@@ -76,3 +76,13 @@ lgen () {
 	cd ..
 	./genext2fs -B $blocksz -N 234 -b $blocks -d $test_dir -D $origin_dir/$devtable -f -o Linux -q $test_img
 }
+
+# agen - Exercises the -a option of genext2fs.
+# Creates an image with a file of given size.
+agen () {
+	blocks=$1; blocksz=$2; tarball=$3
+	echo Testing $blocks blocks of $blocksz bytes with tarball
+	gen_setup
+	echo $tarball | base64 -d | gzip -dc > "$test_dir/input.tar"
+	./genext2fs -B $blocksz -N 17 -b $blocks -a "$test_dir/input.tar" -f -o Linux $test_img
+}

--- a/test.sh
+++ b/test.sh
@@ -48,6 +48,14 @@ ltest () {
 	gen_cleanup
 }
 
+atest() {
+	expected_digest=$1
+	shift
+	agen $@
+	md5cmp $expected_digest
+	gen_cleanup
+}
+
 # NB: always use test-mount.sh to regenerate these digests, that is,
 # replace the following lines with the output of
 # sudo sh test-mount.sh|grep test
@@ -72,3 +80,4 @@ ftest 3db16dd57bd15c1c80dd6bc900411c58 4096 default device_table.txt
 ltest c21b5a3cad405197e821ba7143b0ea9b 200 1024 123456789 device_table_link.txt
 ltest 18b04b4bea2f7ebf315a116be5b92589 200 1024 1234567890 device_table_link.txt
 ltest 8aaed693b75dbdf77607f376d661027a 200 4096 12345678901 device_table_link.txt
+atest 402860495b7e2e1f714e017ef37466c6 200 1024 H4sIAAAAAAACA+3VQQ6CMBCF4a49RU8AnZaZOY8sSIgNTRASj29FVyzUTQno+zYlwAL4M7SqTXEuU+ZlzdbrckxBlJga5SafV/ViLJsNzNfpPFprxpSmd/d9un5QVT3MMZbvL03zfX/yTpyx4Uj9n+9BrzUcp3/Xd2k//UVC7u9Y1FjB/G/QP/bDpZpuU9n+qvpVf9a8T1Bg8sb6LqW6PY9Fn+7v+z8+8n72f2ZZ5p8I+/92/csO2ef/P6/6e/fo79C/uDbO7ckAAAAAAAAAAAAAAAAAwC+4A2+TDLQAKAAA


### PR DESCRIPTION
This pull request fixes https://github.com/bestouff/genext2fs/issues/10

The user interface is changed like this: when no input is given via -d or -D, then genext2fs will open standard input and try reading a tarball from it.

By default, genext2fs tries to create the minimum number of inodes by reading the input twice. This is of course not possible when the input is read from stdin. Thus, the user has to supply the number of inodes manually. To not make this too painful, the new special value 0 got introduced for the -N option which means: compute inode number automatically from the blocksize and number of blocks.

With this commit I can successfully create a full Debian system image like this:

    ./genext2fs -b 144000 -N 0 disk.img < chroot.tar

This is a work in progress. What do you think?