### PR TITLE
read from stdin if filename equals '-' for -D and -a options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ It does not require you to mount the image file to copy files on it, nor
 does it require that you become the superuser to make device nodes.
 
 The filesystem image is created in the file *output-image*. If not
-specified, it is sent to stdout.
+specified, it is sent to stdout. The `-d` and `-a` options support reading
+from stdin if a single hyphen is given as an argument. Thus, genext2fs
+can be used as part of a pipeline without any temporary files.
 
 By default, the maximum number of inodes in the filesystem is the
 minimum number required to accommodate the initial contents. In this
@@ -51,7 +53,8 @@ All specified inodes receive the mtime of **spec-file** itself.
 **-a, --tarball file[:path]**
 
 Add the given archive (tarball) contents at a particular path (by default
-the root).
+the root). If **file** is a hyphen, then the tarball will be read from
+standard input.
 Note: if not compiled with `libarchive`, genext2fs will use a builtin
 tarball parser with very primitive capabilities (e.g. no sparse file
 support, generally no support other than for modern GNU tar without
@@ -67,7 +70,13 @@ Size of a filesystem block in bytes.
 
 **-N, --number-of-inodes inodes**
 
-Maximum number of inodes.
+Minimum number of inodes. The required inode number will be computed
+automatically for all input that is not read from stdin. The number given
+by this option sets the minimum number of inodes. If you add anything
+from standard input, you should set this value because in that case the
+required number of inodes cannot be precomputed. The value set by this
+option will be overwritten by the value computed from the `-i` option,
+if the resulting number of inodes is larger.
 
 **-L, --volume-label name**
 
@@ -75,8 +84,12 @@ Set the volume label for the filesystem.
 
 **-i, --bytes-per-inode ratio**
 
-Used to calculate the maximum number of inodes from the available
-blocks.
+Used to calculate the minimum number of inodes from the available blocks.
+Inodes are computed by multiplying the number of blocks (`-b`) by the blocksize
+(1024) and dividing that by the **ratio** given in this option. If the result
+is larger, then the number of required inodes counted from the input or the
+minimum number of inodes from the `-N` option, then the value computed by
+this option is used.
 
 **-m, --reserved-percentage N**
 

--- a/test-gen.lib
+++ b/test-gen.lib
@@ -51,12 +51,16 @@ dgen () {
 # fgen - Exercises the -D option of genext2fs.
 # Creates an image with the devices listed in the given spec file.
 fgen () {
-	blocks=$1; fname=$3
+	stdin=$1; blocks=$2; fname=$4
 	echo Testing $blocks blocks with with devices file $fname
 	gen_setup
 	cp $origin_dir/$fname $test_dir
 	TZ=UTC-11 touch -t 200502070321.43 $test_dir/$fname
-	./genext2fs -N 92 -b $blocks -D $test_dir/$fname -f -o Linux $test_img
+	if [ "$stdin" = "y" ]; then
+		./genext2fs -N 92 -b $blocks -D - -f -o Linux $test_img < $test_dir/$fname
+	else
+		./genext2fs -N 92 -b $blocks -D $test_dir/$fname -f -o Linux $test_img
+	fi
 }
 
 # lgen - Exercises the -d option of genext2fs, with symlink
@@ -66,7 +70,7 @@ fgen () {
 # NB: some systems including early versions of Mac OS X cannot
 # change symlink timestamps; this test will fail on those systems.
 lgen () {
-	blocks=$1; blocksz=$2; appendage=$3; devtable=$4
+	stdin=$1; blocks=$2; blocksz=$3; appendage=$4; devtable=$5
 	echo Testing $blocks blocks of $blocksz bytes with symlink ...$appendage and devices file $devtable
 	gen_setup
 	cd $test_dir
@@ -74,15 +78,23 @@ lgen () {
 	ln -s $target symlink
 	TZ=UTC-11 touch -h -t 201309241353.59 symlink .
 	cd ..
-	./genext2fs -B $blocksz -N 234 -b $blocks -d $test_dir -D $origin_dir/$devtable -f -o Linux -q $test_img
+	if [ "$stdin" = "y" ]; then
+		./genext2fs -B $blocksz -N 234 -b $blocks -d $test_dir -D - -f -o Linux -q $test_img < $origin_dir/$devtable
+	else
+		./genext2fs -B $blocksz -N 234 -b $blocks -d $test_dir -D $origin_dir/$devtable -f -o Linux -q $test_img
+	fi
 }
 
 # agen - Exercises the -a option of genext2fs.
 # Creates an image with a file of given size.
 agen () {
-	blocks=$1; blocksz=$2; tarball=$3
+	stdin=$1; blocks=$2; blocksz=$3; tarball=$4
 	echo Testing $blocks blocks of $blocksz bytes with tarball
 	gen_setup
 	echo $tarball | base64 -d | gzip -dc > "$test_dir/input.tar"
-	./genext2fs -B $blocksz -N 17 -b $blocks -a "$test_dir/input.tar" -f -o Linux $test_img
+	if [ "$stdin" = "y" ]; then
+		./genext2fs -B $blocksz -N 17 -b $blocks -a - -f -o Linux $test_img < "$test_dir/input.tar"
+	else
+		./genext2fs -B $blocksz -N 17 -b $blocks -a "$test_dir/input.tar" -f -o Linux $test_img
+	fi
 }

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,9 @@ dtest () {
 ftest () {
 	expected_digest=$1
 	shift
-	fgen $@
+	fgen y $@
+	md5cmp $expected_digest
+	fgen n $@
 	md5cmp $expected_digest
 	gen_cleanup
 }
@@ -43,7 +45,9 @@ ftest () {
 ltest () {
 	expected_digest=$1
 	shift
-	lgen $@
+	lgen y $@
+	md5cmp $expected_digest
+	lgen n $@
 	md5cmp $expected_digest
 	gen_cleanup
 }
@@ -51,7 +55,9 @@ ltest () {
 atest() {
 	expected_digest=$1
 	shift
-	agen $@
+	agen y $@
+	md5cmp $expected_digest
+	agen n $@
 	md5cmp $expected_digest
 	gen_cleanup
 }


### PR DESCRIPTION
This pull request adds support for reading the device table or the input tarball from stdin. Only one input can come from stdin. Any input that comes from stdin does not contribute to the computation of stats. I amended the tests such that those tests involving the device table or tarballs are executed twice: once with passing the filename and once with passing `-` and reading from standard input. The output of either must be the same.