### PR TITLE
Don't call ftruncate() on stdout

### DIFF
--- a/genext2fs.c
+++ b/genext2fs.c
@@ -2922,7 +2922,7 @@ copy_file(filesystem *fs, FILE *dst, FILE *src, size_t size)
 		error_msg_and_die("copy_file: out of memory");
 	if (fseek(src, 0, SEEK_SET))
 		perror_msg_and_die("fseek");
-	if (ftruncate(fileno(dst), 0))
+	if ((dst != stdout) && ftruncate(fileno(dst), 0))
 		perror_msg_and_die("copy_file: ftruncate");
 	while (size > 0) {
 		if (fread(b, BLOCKSIZE, 1, src) != 1)


### PR DESCRIPTION
While `-` seems to be explicitly supported as the output option (because `if(strcmp(fsout, "-") == 0)` is checked), this doesn't work since `ftruncate` is called on it anyway in `copy_file`. This commit adds a small check on the given `dst`, just like it does in the loop that actually writes the output.